### PR TITLE
Implement a signer of emails

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -5,6 +5,12 @@
  (libraries logs.fmt fmt.tty dns-client.unix digestif.c dkim))
 
 (executable
+ (name sign_unix)
+ (public_name dkim.sign)
+ (modules sign_unix)
+ (libraries logs.fmt fmt.tty dns-client.unix digestif.c dkim))
+
+(executable
  (name verify_lwt)
  (modules verify_lwt)
  (libraries dns-client.lwt digestif.c dkim))

--- a/bin/sign_unix.ml
+++ b/bin/sign_unix.ml
@@ -1,0 +1,68 @@
+module UnixIO = Dkim.Sigs.Make (struct
+    type +'a t = 'a
+  end)
+
+module Caml_flow = struct
+  type backend = UnixIO.t
+
+  type flow =
+    { ic : in_channel
+    ; buf : Buffer.t }
+
+  let input flow buf off len =
+    let len = Stdlib.input flow.ic buf off len in
+    Buffer.add_string flow.buf (Bytes.sub_string buf off len) ;
+    UnixIO.inj len
+end
+
+module Dns = struct
+  include Dns_client_unix
+
+  type backend = UnixIO.t
+
+  let getaddrinfo t `TXT domain_name =
+    match getaddrinfo t Dns.Rr_map.Txt domain_name with
+    | Ok (_ttl, txtset) -> UnixIO.inj (Ok (Dns.Rr_map.Txt_set.elements txtset))
+    | Error _ as err -> UnixIO.inj err
+end
+
+let ( <.> ) f g x = f (g x)
+
+let unix =
+  { Dkim.Sigs.bind = (fun x f -> f (UnixIO.prj x)); return = UnixIO.inj }
+
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over () ;
+      k () in
+    let with_metadata header _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("%a[%a]: " ^^ fmt ^^ "\n%!")
+        Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
+    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
+  { Logs.report }
+
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+
+let () = Logs.set_reporter (reporter Fmt.stdout)
+
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+
+let seed = Base64.decode_exn "Do8KdmOYnU7yzqDn3A3lJwwXPaa1NRdv6E9R2KgZyXg="
+
+let priv_of_seed seed =
+  let g =
+    let seed = Cstruct.of_string seed in
+    Mirage_crypto_rng.(create ~seed (module Fortuna)) in
+  Mirage_crypto_pk.Rsa.generate ~g ~bits:2048 ()
+
+let () =
+  let stdin = { Caml_flow.ic= stdin; buf= Buffer.create 0x1000; } in
+  let key = priv_of_seed seed in
+  let dkim = Dkim.v ~selector:"admin" ((Domain_name.host_exn <.> Domain_name.of_string_exn) "x25519.net") in
+  let dkim = UnixIO.prj (Dkim.sign ~key stdin unix (module Caml_flow) dkim) in
+  Fmt.pr "%s" (Prettym.to_string ~new_line:"\n" Dkim.Encoder.as_field dkim) ;
+  Fmt.pr "%s" (Buffer.contents stdin.Caml_flow.buf)

--- a/lib/decoder.ml
+++ b/lib/decoder.ml
@@ -428,7 +428,7 @@ let server_tag_list =
   let tag_spec = v <|> h <|> k <|> n <|> p <|> s <|> t in
   tag_spec >>= function
   | Some (Map.B (k, v)) ->
-      many (char ';' *> tag_spec)
+      many (char ';' *> tag_spec) <* option () (char ';' *> return ())
       >>| List.fold_left
             (fun hmap -> function Some (Map.B (k, v)) -> Map.add k v hmap
               | None -> hmap)

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
 (executable
  (name test)
  (modules test)
- (libraries logs.fmt fmt.tty digestif.c dkim alcotest))
+ (libraries mirage-crypto-rng.unix logs.fmt fmt.tty digestif.c dkim alcotest))
 
 (rule
  (alias runtest)

--- a/test/test.ml
+++ b/test/test.ml
@@ -47,7 +47,7 @@ let priv_of_seed, pub_of_seed =
   key, Cstruct.to_string (X509.Public_key.encode_der (`RSA public))
 
 let admin__domainkey_x25519_net =
-  Fmt.strf "k=rsa; p=%s" (Base64.encode_exn ~pad:true pub_of_seed)
+  Fmt.strf "k=rsa; p=%s;" (Base64.encode_exn ~pad:true pub_of_seed)
 
 let mails = [ 2, "raw/001.mail"; 1, "raw/002.mail"; 1, "raw/003.mail" ]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,3 +1,5 @@
+let () = Mirage_crypto_rng_unix.initialize ()
+
 let reporter ppf =
   let report src level ~over k msgf =
     let k _ =
@@ -34,7 +36,20 @@ let google__domainkey_janestreet_com =
   "v=DKIM1; k=rsa; \
    p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZr8DcbuZ/BsBrNh7kyYIM6tO3Z4P3UQKuyKSN9nFmPlCmkYu7A6zm+069O3iwNUvyHwk+n67KyNzA6mC4B4/x/NHZ1gr6rXJoAha4ORxNPPpxUWKfYsCwnaSP9c8HgWOw4HigJReR5G1kiamGL+4BNy/WknWxT04E6I3c+KEOIQIDAQAB"
 
-let mails = [ "raw/001.mail"; "raw/002.mail"; "raw/003.mail" ]
+let seed = Base64.decode_exn "Do8KdmOYnU7yzqDn3A3lJwwXPaa1NRdv6E9R2KgZyXg="
+
+let priv_of_seed, pub_of_seed =
+  let g =
+    let seed = Cstruct.of_string seed in
+    Mirage_crypto_rng.(create ~seed (module Fortuna)) in
+  let key = Mirage_crypto_pk.Rsa.generate ~g ~bits:2048 () in
+  let public = Mirage_crypto_pk.Rsa.pub_of_priv key in
+  key, Cstruct.to_string (X509.Public_key.encode_der (`RSA public))
+
+let admin__domainkey_x25519_net =
+  Fmt.strf "k=rsa; p=%s" (Base64.encode_exn ~pad:true pub_of_seed)
+
+let mails = [ 2, "raw/001.mail"; 1, "raw/002.mail"; 1, "raw/003.mail" ]
 
 module Unix_scheduler = Dkim.Sigs.Make (struct
   type +'a t = 'a
@@ -66,6 +81,8 @@ module Fake_resolver = struct
         Unix_scheduler.inj (Ok [ pf2014__domainkey_github_com ])
     | [ "google"; "_domainkey"; "janestreet"; "com" ] ->
         Unix_scheduler.inj (Ok [ google__domainkey_janestreet_com ])
+    | [ "admin"; "_domainkey"; "x25519"; "net" ] ->
+        Unix_scheduler.inj (Ok [ admin__domainkey_x25519_net ])
     | _ ->
         Unix_scheduler.inj
           (Rresult.R.error_msgf "domain %a does not exists"
@@ -89,9 +106,7 @@ let verify ic =
   let errors = ref [] in
 
   match Dkim.extract_dkim ic unix (module Caml_flow) |> Unix_scheduler.prj with
-  | Error _ as err ->
-      Fmt.epr ">>> Impossible to extract DKIM field.\n%!" ;
-      err
+  | Error _ as err -> err
   | Ok extracted -> (
       let dkim_fields =
         List.fold_left
@@ -145,17 +160,47 @@ let verify ic =
             errors ;
           Error (`Msg "Got errors while computing inputs"))
 
-let test filename =
+let test_verify (trust, filename) =
   Alcotest.test_case filename `Quick @@ fun () ->
   let ic = open_in filename in
   let rs = verify ic in
   close_in ic ;
   match rs with
   | Ok rs ->
+    Alcotest.(check int) "DKIM fields" (List.length rs) trust ;
       List.iter
         (fun (domain, res) ->
           Alcotest.(check bool) (Domain_name.to_string domain) res true)
         rs
   | Error (`Msg err) -> Alcotest.fail err
 
-let () = Alcotest.run "ocaml-dkim" [ ("tests", List.map test mails) ]
+let ( <.> ) f g = fun x -> f (g x)
+
+let test_sign (trust, filename) =
+  Alcotest.test_case filename `Quick @@ fun () ->
+  let ic = open_in filename in
+  let x25519 = Domain_name.(host_exn <.> of_string_exn) "x25519.net" in
+  let dkim = Dkim.v ~selector:"admin" x25519 in
+  let dkim = Unix_scheduler.prj (Dkim.sign ~key:priv_of_seed ic unix (module Caml_flow) dkim) in
+  let oc = open_out (filename ^ ".signed") in
+  seek_in ic 0 ;
+  output_string oc (Prettym.to_string ~new_line:"\n" Dkim.Encoder.as_field dkim) ;
+  let tmp = Bytes.create 0x1000 in
+  let rec go () =
+    let len = input ic tmp 0 (Bytes.length tmp) in
+    if len = 0 then ()
+    else ( output_string oc (Bytes.sub_string tmp 0 len) ; go () ) in
+  go () ; close_in ic ; close_out oc ;
+  let ic = open_in (filename ^ ".signed") in
+  let rs = verify ic in
+  match rs with
+  | Ok rs ->
+    Alcotest.(check int) "DKIM fields" (List.length rs) (succ trust) ;
+    List.iter
+      (fun (domain, res) ->
+         Alcotest.(check bool) (Domain_name.to_string domain) res true)
+      rs
+  | Error (`Msg err) -> Alcotest.fail err
+
+let () = Alcotest.run "ocaml-dkim" [ ("verify", List.map test_verify mails)
+                                   ; ("sign", List.map test_sign mails) ]


### PR DESCRIPTION
First implementation of a signer. We should use raw emails stored in test to ensure with a fake DNS resolver that emails are correctly signed.