### PR TITLE
Upgrade with dns.5.0.0 and mirage-crypto.0.9.2 (with ed25519)

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -4,7 +4,7 @@
  (package dkim)
  (modules verify)
  (libraries logs.cli fmt.cli logs.fmt fmt.tty dns-client.unix cmdliner fpath
-   digestif.c dkim))
+   digestif.c ipaddr.unix dkim))
 
 (executable
  (name sign)

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -70,7 +70,7 @@ let exit_failure = 1
 let run quiet src newline nameserver =
   let nameserver =
     match nameserver with
-    | Some (inet_addr, port) -> Some (`TCP, (inet_addr, port))
+    | Some (inet_addr, port) -> Some (`TCP, (Ipaddr_unix.of_inet_addr inet_addr, port))
     | None -> None in
   let dns = Dns_client_unix.create ?nameserver () in
   let flow = Flow.of_input src in

--- a/dkim-mirage.opam
+++ b/dkim-mirage.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
   "dkim"       {= version}
-  "dns-client"
+  "dns-client" {>= "5.0.0"}
   "mirage-time"
   "mirage-random"
   "mirage-clock"

--- a/dkim.opam
+++ b/dkim.opam
@@ -25,14 +25,14 @@ depends: [
   "base-unix"
   "hmap"
   "domain-name"
-  "dns-client"
+  "dns-client" {>= "5.0.0"}
   "cmdliner"
   "logs"
   "fmt"
   "fpath"
   "base64"     {>= "3.0.0"}
-  "mirage-crypto"
-  "mirage-crypto-pk"
+  "mirage-crypto" {>= "0.9.2"}
+  "mirage-crypto-pk" {>= "0.9.2"}
   "x509" {>= "0.6.3"}
   "alcotest"   {with-test}
 ]

--- a/lib/dkim.mli
+++ b/lib/dkim.mli
@@ -55,6 +55,8 @@ val selector : 'a dkim -> [ `raw ] Domain_name.t
 val domain : 'a dkim -> [ `raw ] Domain_name.t
 (** [domain dkim] returns the domain which signed the mail. *)
 
+val fields : 'a dkim -> Mrmime.Field_name.t list
+
 val domain_name :
   'a dkim -> ([ `raw ] Domain_name.t, [> `Msg of string ]) result
 (** [domain_name dkim] returns the full domain-name where the DNS TXT record can

--- a/lib/value.ml
+++ b/lib/value.ml
@@ -1,4 +1,4 @@
-type algorithm = RSA | Algorithm_ext of string
+type algorithm = RSA | ED25519 | Algorithm_ext of string
 
 type hash = SHA1 | SHA256 | Hash_ext of string
 
@@ -36,6 +36,7 @@ type server_version = string
 
 let pp_algorithm ppf = function
   | RSA -> Fmt.string ppf "rsa"
+  | ED25519 -> Fmt.string ppf "ed25519"
   | Algorithm_ext x -> Fmt.string ppf x
 
 let pp_hash ppf = function

--- a/mirage/dkim_mirage.ml
+++ b/mirage/dkim_mirage.ml
@@ -65,7 +65,7 @@ module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
-    (S : Mirage_stack.V4) =
+    (S : Mirage_stack.V4V6) =
 struct
   module DNS = struct
     include Dns_client_mirage.Make (R) (T) (C) (S)

--- a/mirage/dkim_mirage.mli
+++ b/mirage/dkim_mirage.mli
@@ -4,11 +4,11 @@ module Make
     (R : Mirage_random.S)
     (T : Mirage_time.S)
     (C : Mirage_clock.MCLOCK)
-    (S : Mirage_stack.V4) : sig
+    (S : Mirage_stack.V4V6) : sig
   val verify :
     ?newline:Dkim.newline ->
     ?size:int ->
-    ?nameserver:[ `TCP | `UDP ] * (Ipaddr.V4.t * int) ->
+    ?nameserver:[ `TCP | `UDP ] * (Ipaddr.t * int) ->
     ?timeout:int64 ->
     (string * int * int) stream ->
     S.t ->


### PR DESCRIPTION
We currently try to support Ed25519 - however, I don't test it. According RFC 8032:
> The ed25519-sha256 signing algorithm computes a message hash as defined in section 3 of [RFC6376] using SHA-256 [FIPS-180-4-2015] as the hash-alg, and signs it with the PureEdDSA variant Ed25519, as defined in in RFC 8032 section 5.1. Example keys and signatures in Appendix A below are based on the test vectors in RFC 8032 section 7.1.

So, PureEdDSA must be used to verify emails. Note that we can not sign yet with Ed25519. Not sure that it's the right way so we need to check.