### PR TITLE
Update the interface to allow a real one pass to verify incoming emails

### DIFF
--- a/lib/sigs.ml
+++ b/lib/sigs.ml
@@ -9,6 +9,8 @@ type 't state = {
   return : 'a. 'a -> ('a, 't) io;
 }
 
+type 't both = { f : 'a 'b. ('a, 't) io -> ('b, 't) io -> ('a * 'b, 't) io }
+
 module type X = sig
   type 'a s
 
@@ -39,6 +41,16 @@ module type FLOW = sig
   type flow
 
   val input : flow -> bytes -> int -> int -> (int, backend) io
+end
+
+module type STREAM = sig
+  type backend
+
+  type 'a t
+
+  val create : unit -> 'a t * ('a option -> unit)
+
+  val get : 'a t -> ('a option, backend) io
 end
 
 module type DNS = sig

--- a/lib/sigs.mli
+++ b/lib/sigs.mli
@@ -9,6 +9,8 @@ type 't state = {
   return : 'a. 'a -> ('a, 't) io;
 }
 
+type 't both = { f : 'a 'b. ('a, 't) io -> ('b, 't) io -> ('a * 'b, 't) io }
+
 module type X = sig
   type 'a s
 
@@ -27,6 +29,16 @@ module type FLOW = sig
   type flow
 
   val input : flow -> bytes -> int -> int -> (int, backend) io
+end
+
+module type STREAM = sig
+  type backend
+
+  type 'a t
+
+  val create : unit -> 'a t * ('a option -> unit)
+
+  val get : 'a t -> ('a option, backend) io
 end
 
 module type DNS = sig


### PR DESCRIPTION
This huge patch wants to provide a real way to analyze the incoming email in one pass without a huge memory presure. It bounds the incoming email and verify concurrently DKIM fields to be sure to have a stable memory consumption.