### PR TITLE
Fix a real stream of DKIM

### DIFF
--- a/lib/dkim.mli
+++ b/lib/dkim.mli
@@ -28,6 +28,7 @@ type extracted = {
 
 val extract_dkim :
   ?newline:newline ->
+  ?size:int ->
   'flow ->
   't Sigs.state ->
   (module Sigs.FLOW with type flow = 'flow and type backend = 't) ->


### PR DESCRIPTION
Some fix and introspection of our assumptions with some comments. The `dkim-mirage` `verify` function is memory bounded.